### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ mcount := socket.recv( tsl );
 **CTRL+C Handling**
 
 it's a bit tricky. On windows signal handling is different, than in posix systems.
-Blocking calls won't receive SIGINT, just block continously. To overcome this issue,
+Blocking calls won't receive SIGINT, just block continuously. To overcome this issue,
 the installed handler terminates the contexts, so blocking calls like `recv`, `poll`,
 etc... will receive `ETERM`. It's just on Windows.
 


### PR DESCRIPTION
@bvarga, I've corrected a typographical error in the documentation of the [delphizmq](https://github.com/bvarga/delphizmq) project. Specifically, I've changed continous to continuous. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.