### PR TITLE
add static link support for unix

### DIFF
--- a/zmq.pas
+++ b/zmq.pas
@@ -22,6 +22,14 @@ unit zmq;
   {$linklib pthread}
 {$endif}
 
+{$IFDEF ZMQ_STATIC_LINK}
+  {$IFDEF UNIX}
+    {$LINKLIB stdc++}
+    {$LINKLIB gcc_s}
+    {$LINK /usr/local/lib/libzmq.a}
+  {$ENDIF}
+{$ENDIF}
+
 {$I zmq.inc}
 
 interface
@@ -31,15 +39,17 @@ uses
   ctypes;
 {$endif}
 
+{$IFNDEF ZMQ_STATIC_LINK}
 const
   {$ifdef UNIX}
   libzmq = 'libzmq.so';
   {$else}
   libzmq = 'libzmq.dll';
   {$endif}
+{$ENDIF}
 
 {  Run-time API version detection                                              }
-procedure zmq_version( var major, minor, patch: Integer ); cdecl; external libzmq;
+procedure zmq_version( var major, minor, patch: Integer ); cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
 
 {******************************************************************************}
 {*  0MQ errors.                                                               *}
@@ -80,10 +90,10 @@ const
 {*  of this function is to make the code 100% portable, including where 0MQ   *}
 {*  compiled with certain CRT library (on Windows) is linked to an            *}
 {*  application that uses different CRT library.                              *}
-function zmq_errno: Integer; cdecl; external libzmq;
+function zmq_errno: Integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
 
 {*  Resolves system errors and 0MQ errors to human-readable string.           *}
-function zmq_strerror(errnum: Integer):PAnsiChar; cdecl; external libzmq;
+function zmq_strerror(errnum: Integer):PAnsiChar; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
 
 {******************************************************************************}
 {*  0MQ infrastructure (a.k.a. context) initialisation & termination.         *}
@@ -100,15 +110,15 @@ const
   ZMQ_IO_THREADS_DFLT = 1;
   ZMQ_MAX_SOCKETS_DFLT = 1024;
 
-function zmq_ctx_new: Pointer; cdecl; external libzmq;
-function zmq_ctx_destroy( context: Pointer ): Integer; cdecl; external libzmq;
-function zmq_ctx_set( context: Pointer; option: Integer; optval: Integer ): Integer; cdecl; external libzmq;
-function zmq_ctx_get( context: Pointer; option: Integer ): Integer; cdecl; external libzmq;
+function zmq_ctx_new: Pointer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+function zmq_ctx_destroy( context: Pointer ): Integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+function zmq_ctx_set( context: Pointer; option: Integer; optval: Integer ): Integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+function zmq_ctx_get( context: Pointer; option: Integer ): Integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
 {$endif}
 
 {*  Old (legacy) API                                                          *}
-function zmq_init(io_threads: Integer): Pointer; cdecl; external libzmq;
-function zmq_term(context: Pointer): Integer; cdecl; external libzmq;
+function zmq_init(io_threads: Integer): Pointer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+function zmq_term(context: Pointer): Integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
 
 {******************************************************************************}
 {*  0MQ message definition.                                                   *}
@@ -158,29 +168,29 @@ type
 
   free_fn = procedure(data, hint: Pointer);
 
-{$ifdef FPC}  
+{$ifdef FPC}
   size_t = clong;
 {$else}
   size_t = Cardinal;
 {$endif}
 
-function zmq_msg_init( var msg: zmq_msg_t ): Integer; cdecl; external libzmq;
-function zmq_msg_init_size( var msg: zmq_msg_t; size: size_t ): Integer; cdecl; external libzmq;
+function zmq_msg_init( var msg: zmq_msg_t ): Integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+function zmq_msg_init_size( var msg: zmq_msg_t; size: size_t ): Integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
 function zmq_msg_init_data( var msg: zmq_msg_t; data: Pointer; size: size_t;
-  ffn: free_fn; hint: Pointer ): Integer; cdecl; external libzmq;
+  ffn: free_fn; hint: Pointer ): Integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
 
-function zmq_msg_close(var msg: zmq_msg_t): Integer; cdecl; external libzmq;
-function zmq_msg_move(dest, src: zmq_msg_t): Integer; cdecl; external libzmq;
-function zmq_msg_copy(dest, src: zmq_msg_t): Integer; cdecl; external libzmq;
-function zmq_msg_data(var msg: zmq_msg_t): Pointer; cdecl; external libzmq;
-function zmq_msg_size(var msg: zmq_msg_t): size_t; cdecl; external libzmq;
+function zmq_msg_close(var msg: zmq_msg_t): Integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+function zmq_msg_move(dest, src: zmq_msg_t): Integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+function zmq_msg_copy(dest, src: zmq_msg_t): Integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+function zmq_msg_data(var msg: zmq_msg_t): Pointer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+function zmq_msg_size(var msg: zmq_msg_t): size_t; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
 
 {$ifdef zmq3}
-function zmq_msg_more (var msg: zmq_msg_t): Integer; cdecl; external libzmq;
-function zmq_msg_get (var msg: zmq_msg_t; option: Integer): Integer; cdecl; external libzmq;
-function zmq_msg_set (var msg: zmq_msg_t; option: Integer; optval: Integer): Integer; cdecl; external libzmq;
-function zmq_msg_send (var msg: zmq_msg_t; s: Pointer; flags: Integer): Integer; cdecl; external libzmq;
-function zmq_msg_recv (var msg: zmq_msg_t; s: Pointer; flags: Integer): Integer; cdecl; external libzmq;
+function zmq_msg_more (var msg: zmq_msg_t): Integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+function zmq_msg_get (var msg: zmq_msg_t; option: Integer): Integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+function zmq_msg_set (var msg: zmq_msg_t; option: Integer; optval: Integer): Integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+function zmq_msg_send (var msg: zmq_msg_t; s: Pointer; flags: Integer): Integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+function zmq_msg_recv (var msg: zmq_msg_t; s: Pointer; flags: Integer): Integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
 {$endif}
 {******************************************************************************}
 {*  0MQ socket definition.                                                    *}
@@ -326,30 +336,30 @@ type
 
 {$endif}
 
-function zmq_socket(context: Pointer; stype: Integer): Pointer; cdecl; external libzmq;
-function zmq_close(s: Pointer): Integer; cdecl; external libzmq;
-function zmq_setsockopt(s: Pointer; option: Integer; optval: Pointer; optvallen: size_t ): Integer; cdecl; external libzmq;
-function zmq_getsockopt(s: Pointer; option: Integer; optval: Pointer; var optvallen: size_t): Integer; cdecl; external libzmq;
-function zmq_bind(s: Pointer; addr: PAnsiChar): Integer; cdecl; external libzmq;
-function zmq_connect(s: Pointer; addr: PAnsiChar): Integer; cdecl; external libzmq;
+function zmq_socket(context: Pointer; stype: Integer): Pointer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+function zmq_close(s: Pointer): Integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+function zmq_setsockopt(s: Pointer; option: Integer; optval: Pointer; optvallen: size_t ): Integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+function zmq_getsockopt(s: Pointer; option: Integer; optval: Pointer; var optvallen: size_t): Integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+function zmq_bind(s: Pointer; addr: PAnsiChar): Integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+function zmq_connect(s: Pointer; addr: PAnsiChar): Integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
 {$ifdef zmq3}
-function zmq_unbind(s: Pointer; addr: PAnsiChar): Integer; cdecl; external libzmq;
-function zmq_disconnect(s: Pointer; addr: PAnsiChar): Integer; cdecl; external libzmq;
+function zmq_unbind(s: Pointer; addr: PAnsiChar): Integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+function zmq_disconnect(s: Pointer; addr: PAnsiChar): Integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
 {$endif}
 
 {$ifdef zmq3}
-function zmq_send (s: Pointer; const buffer; len: size_t; flags: Integer): Integer; cdecl; external libzmq;
-function zmq_recv (s: Pointer; var buffer; len: size_t; flags: Integer): Integer; cdecl; external libzmq;
+function zmq_send (s: Pointer; const buffer; len: size_t; flags: Integer): Integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+function zmq_recv (s: Pointer; var buffer; len: size_t; flags: Integer): Integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
 {$else}
-function zmq_send (s: Pointer; var msg: zmq_msg_t; flags: Integer): Integer; cdecl; external libzmq;
-function zmq_recv (s: Pointer; var msg: zmq_msg_t; flags: Integer): Integer; cdecl; external libzmq;
+function zmq_send (s: Pointer; var msg: zmq_msg_t; flags: Integer): Integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+function zmq_recv (s: Pointer; var msg: zmq_msg_t; flags: Integer): Integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
 {$endif}
 
 {$ifdef zmq3}
-function zmq_sendmsg(s: Pointer; var msg: zmq_msg_t; flags: Integer): Integer; cdecl; external libzmq;
-function zmq_recvmsg(s: Pointer; var msg: zmq_msg_t; flags: Integer): Integer; cdecl; external libzmq;
+function zmq_sendmsg(s: Pointer; var msg: zmq_msg_t; flags: Integer): Integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+function zmq_recvmsg(s: Pointer; var msg: zmq_msg_t; flags: Integer): Integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
 
-function zmq_socket_monitor( s: Pointer; addr: PAnsiChar; events: Integer ): Integer; cdecl; external libzmq;
+function zmq_socket_monitor( s: Pointer; addr: PAnsiChar; events: Integer ): Integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
 
 {
 /*  Experimental                                                              */
@@ -376,7 +386,7 @@ type
     revents: Word;
   end;
 
-function zmq_poll( var items: pollitem_t; nitems: Integer; timeout: Longint ): Integer; cdecl; external libzmq;
+function zmq_poll( var items: pollitem_t; nitems: Integer; timeout: Longint ): Integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
 
 {******************************************************************************}
 {*  Built-in devices                                                          *}
@@ -384,7 +394,7 @@ function zmq_poll( var items: pollitem_t; nitems: Integer; timeout: Longint ): I
 
 {$ifdef zmq3}
 {*  Built-in message proxy (3-way) *}
-function zmq_proxy( frontend, backend, capture: Pointer ): Integer; cdecl; external libzmq;
+function zmq_proxy( frontend, backend, capture: Pointer ): Integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
 
 {$endif}
 {*  Deprecated aliases *}
@@ -392,22 +402,22 @@ const
   ZMQ_STREAMER = 1;
   ZMQ_FORWARDER = 2;
   ZMQ_QUEUE = 3;
-  
+
 {*  Deprecated method *}
-function zmq_device(device: Integer; insocket,outsocket: Pointer): Integer; cdecl; external libzmq;
+function zmq_device(device: Integer; insocket,outsocket: Pointer): Integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
 
 {*  Helper functions are used by perf tests so that they don't have to care   *}
 {*  about minutiae of time-related functions on different OS platforms.       *}
 
 {*  Starts the stopwatch. Returns the handle to the watch.                    *}
-function zmq_stopwatch_start: Pointer; stdcall; external libzmq;
+function zmq_stopwatch_start: Pointer; stdcall; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
 
 {*  Stops the stopwatch. Returns the number of microseconds elapsed since     *}
 {*  the stopwatch was started.                                                *}
-function zmq_stopwatch_stop( watch: Pointer ): LongWord; stdcall; external libzmq;
+function zmq_stopwatch_stop( watch: Pointer ): LongWord; stdcall; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
 
 {*  Sleeps for specified number of seconds.                                   *}
-procedure zmq_sleep( seconds: Integer ); stdcall; external libzmq;
+procedure zmq_sleep( seconds: Integer ); stdcall; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
 
 implementation
 


### PR DESCRIPTION
Requires a `libzmq.a` library compiled with the --static configuration.